### PR TITLE
build docker image on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,10 @@ addons:
 
 install:
   - docker build -t apinf/proxy42:travis .
-  - docker run -d -p 4001:4001 -p 8080:8080 apinf/proxy42:travis foreground
+  - docker run --name proxy42_travis -d -p 4001:4001 -p 8080:8080 apinf/proxy42:travis
   - docker ps -a
+  - sleep 10 # Ugly hack to make sure p42 is up
+  - docker logs proxy42_travis
 
 script:
   - bash ./apps/proxy42_control_api/test/apitest.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,20 @@
-sudo: required
+dist: xenial
+language: minimal
 
-language: elixir
+# Since we'll just be building a docker image and using it,
+# ignore the elixir image for now. Change to elixir image when we have some unit tests.
+#
+# language: elixir
+# elixir:
+#   - '1.7.4'
+# otp_release:
+#   - '19.2'
+
+## Add more versions to test against when upgrading.
+# matrix:
+#   include:
+#     - elixir: '1.7.4'
+#       otp_release: '19.2'
 
 services:
   - docker
@@ -10,9 +24,9 @@ addons:
     packages:
       httpie
 
-before_install:
-  - docker pull apinf/proxy42:release
-  - docker run -d -p 4001:4001 -p 8080:8080 apinf/proxy42:release foreground
+install:
+  - docker build -t apinf/proxy42:travis .
+  - docker run -d -p 4001:4001 -p 8080:8080 apinf/proxy42:travis foreground
   - docker ps -a
 
 script:

--- a/apps/p42_admin/config/prod.exs
+++ b/apps/p42_admin/config/prod.exs
@@ -69,4 +69,5 @@ config :p42_admin, P42Admin.Endpoint,
 
 # Finally import the config/prod.secret.exs which should be versioned
 # separately.
-import_config "prod.secret.exs"
+# Wildcard fails silently if file doesn't exist. Better IMO than breaking build.
+import_config "prod.*.exs"


### PR DESCRIPTION
Current travis config is kind of a joke since it runs the same script against same pre baked image. It gets deps because of language:elixir, but that's it.

This change switches to building a new image from scratch on travis and using that for tests. Since we're not using elixir for now I made it explicit by switching to `language: minimal`