### PR TITLE
Refactor circular deps between plugin and core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ erl_crash.dump
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
 
+# IDE's
+*.sublime-*
+
 # Ignore Mnesia db folder
 Mnesia*
 build

--- a/apps/proxy42_core/src/proxy42_api_logger.erl
+++ b/apps/proxy42_core/src/proxy42_api_logger.erl
@@ -1,0 +1,53 @@
+%%
+%% @doc
+%%   core api for logger plug-ins
+-module(proxy42_api_logger).
+
+-export([message/2]).
+
+%% TODO: Add developer_id and user_id to log.
+-define(METADATA, [
+   incoming_ip
+,  domain
+,  method
+,  path
+,  request_id
+,  api_id
+,  developer_id
+,  user_id
+,  response_code
+]).
+
+%%
+%% @doc
+%%   transforms internal context into logger report
+-spec message(_, _) -> _.
+
+message(LogInfo, Request) ->
+   [message_events(LogInfo) | message_metadata(Request)].
+
+message_metadata(Request) ->
+   lists:map(
+      fun(X) -> {X, p42_req_ctx:ctx_get(X, Request)} end,
+      ?METADATA
+   ).
+
+message_events(LogInfo) ->
+   {events, lists:map(fun format_event/1, LogInfo)}.
+
+
+format_event({Time, Event, no_details}) ->
+  format_event(Time, Event);
+format_event({Time, Event, Detail}) when is_atom(Detail) ->
+  format_event(Time, key(Event, Detail)).
+
+format_event(Time, Event) ->
+  {Event, timestamp(Time)}.
+
+key(E, D) ->
+  E1 = erlang:atom_to_binary(E, utf8),
+  D1 = erlang:atom_to_binary(D, utf8),
+  <<E1/binary, ":" ,D1/binary>>.
+
+timestamp({MegaSecs, Secs, MicroSecs}) ->
+  (MegaSecs * 1000000 + Secs) * 1000 + (MicroSecs div 1000).

--- a/apps/proxy42_core/src/proxy42_router.erl
+++ b/apps/proxy42_core/src/proxy42_router.erl
@@ -222,5 +222,6 @@ terminate(RespStatus, Upstream, State) ->
   ok.
 
 dispatch_logs(LogInfo, State) ->
+  Message = proxy42_api_logger:message(LogInfo, State),
   LogMod = get_log_strategy(State),
-  LogMod:log(LogInfo, State).
+  LogMod:log(Message).


### PR DESCRIPTION
__WHY__
Logger plugin has deps to internal core structures (e.g. LogInfo, ReqCtx). It leads to development  practice where thin interface between core and plugin is vanished. Instead logger plugin should not care more about anything expect sinking the document to output media.

__WHAT__
* define core logger api (behaviour)
* move document formatting to core part
 